### PR TITLE
Add product CRUD UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+my-app/node_modules/
+my-app/package-lock.json

--- a/my-app/src/ProductCatalog.jsx
+++ b/my-app/src/ProductCatalog.jsx
@@ -1,26 +1,48 @@
 import { useState } from 'react'
 import './ProductCatalog.css'
+import ProductForm from './ProductForm.jsx'
 const placeholder = 'https://via.placeholder.com/50'
 
-export default function ProductCatalog() {
-  const products = [
-    { sku: 'SKU001', name: 'Widget A', categories: ['Tools'], price: '$9.99', image: placeholder },
-    { sku: 'SKU002', name: 'Gadget B', categories: ['Electronics'], price: '$19.99', image: placeholder },
-    { sku: 'SKU003', name: 'Thingamajig C', categories: ['Accessories'], price: '$5.50', image: placeholder },
-    { sku: 'SKU004', name: 'Doohickey D', categories: ['Tools', 'Outdoor'], price: '$14.25', image: placeholder },
-    { sku: 'SKU005', name: 'Widget E', categories: ['Tools'], price: '$8.00', image: placeholder },
-    { sku: 'SKU006', name: 'Gadget F', categories: ['Electronics'], price: '$22.00', image: placeholder },
-    { sku: 'SKU007', name: 'Thingamabob G', categories: ['Accessories'], price: '$11.75', image: placeholder },
-    { sku: 'SKU008', name: 'Widget H', categories: ['Outdoor'], price: '$6.40', image: placeholder },
-    { sku: 'SKU009', name: 'Gizmo I', categories: ['Electronics', 'Tools'], price: '$13.30', image: placeholder },
-    { sku: 'SKU010', name: 'Contraption J', categories: ['Home'], price: '$15.00', image: placeholder },
-    { sku: 'SKU011', name: 'Device K', categories: ['Electronics'], price: '$18.25', image: placeholder },
-    { sku: 'SKU012', name: 'Thingy L', categories: ['Accessories', 'Home'], price: '$7.99', image: placeholder }
-  ]
+const initialProducts = [
+  { sku: 'SKU001', name: 'Widget A', categories: ['Tools'], price: 9.99, image: placeholder, brand: 'Brand A', discount: 0 },
+  { sku: 'SKU002', name: 'Gadget B', categories: ['Electronics'], price: 19.99, image: placeholder, brand: 'Brand B', discount: 0 },
+  { sku: 'SKU003', name: 'Thingamajig C', categories: ['Accessories'], price: 5.5, image: placeholder, brand: 'Brand C', discount: 0 },
+  { sku: 'SKU004', name: 'Doohickey D', categories: ['Tools', 'Outdoor'], price: 14.25, image: placeholder, brand: 'Brand A', discount: 0 },
+  { sku: 'SKU005', name: 'Widget E', categories: ['Tools'], price: 8.0, image: placeholder, brand: 'Brand B', discount: 0 },
+  { sku: 'SKU006', name: 'Gadget F', categories: ['Electronics'], price: 22.0, image: placeholder, brand: 'Brand C', discount: 0 },
+  { sku: 'SKU007', name: 'Thingamabob G', categories: ['Accessories'], price: 11.75, image: placeholder, brand: 'Brand A', discount: 0 },
+  { sku: 'SKU008', name: 'Widget H', categories: ['Outdoor'], price: 6.4, image: placeholder, brand: 'Brand B', discount: 0 },
+  { sku: 'SKU009', name: 'Gizmo I', categories: ['Electronics', 'Tools'], price: 13.3, image: placeholder, brand: 'Brand C', discount: 0 },
+  { sku: 'SKU010', name: 'Contraption J', categories: ['Home'], price: 15.0, image: placeholder, brand: 'Brand A', discount: 0 },
+  { sku: 'SKU011', name: 'Device K', categories: ['Electronics'], price: 18.25, image: placeholder, brand: 'Brand B', discount: 0 },
+  { sku: 'SKU012', name: 'Thingy L', categories: ['Accessories', 'Home'], price: 7.99, image: placeholder, brand: 'Brand C', discount: 0 }
+]
 
+export default function ProductCatalog() {
+  const [products, setProducts] = useState(initialProducts)
+  const [editingIndex, setEditingIndex] = useState(null)
+  const [showForm, setShowForm] = useState(false)
   const [search, setSearch] = useState('')
   const [page, setPage] = useState(1)
   const pageSize = 5
+
+  const addProduct = product => {
+    setProducts([...products, product])
+    setShowForm(false)
+    setPage(Math.ceil((products.length + 1) / pageSize))
+  }
+
+  const updateProduct = product => {
+    setProducts(products.map((p, i) => (i === editingIndex ? product : p)))
+    setEditingIndex(null)
+    setShowForm(false)
+  }
+
+  const deleteProduct = index => {
+    const newProducts = products.filter((_, i) => i !== index)
+    setProducts(newProducts)
+    setPage(p => Math.min(Math.ceil(newProducts.length / pageSize) || 1, p))
+  }
 
   const filtered = products.filter(p =>
     p.name.toLowerCase().includes(search.toLowerCase()) ||
@@ -37,6 +59,15 @@ export default function ProductCatalog() {
   return (
     <div className="catalog">
       <h2>Product Catalog</h2>
+      {showForm ? (
+        <ProductForm
+          onSave={editingIndex !== null ? updateProduct : addProduct}
+          onCancel={() => { setShowForm(false); setEditingIndex(null) }}
+          initial={editingIndex !== null ? products[editingIndex] : null}
+        />
+      ) : (
+        <button onClick={() => setShowForm(true)}>Add Product</button>
+      )}
       <input
         className="search"
         placeholder="Search..."
@@ -49,20 +80,32 @@ export default function ProductCatalog() {
             <th>Product Image</th>
             <th>SKU</th>
             <th>Product Name</th>
+            <th>Brand</th>
             <th>Categories</th>
             <th>Price</th>
+            <th>Discount %</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
-          {paginated.map(p => (
-            <tr key={p.sku}>
-              <td><img className="thumbnail" src={p.image} alt={p.name} /></td>
-              <td>{p.sku}</td>
-              <td>{p.name}</td>
-              <td>{p.categories.join(', ')}</td>
-              <td>{p.price}</td>
-            </tr>
-          ))}
+          {paginated.map((p, i) => {
+            const index = start + i
+            return (
+              <tr key={p.sku}>
+                <td><img className="thumbnail" src={p.image} alt={p.name} /></td>
+                <td>{p.sku}</td>
+                <td>{p.name}</td>
+                <td>{p.brand}</td>
+                <td>{p.categories.join(', ')}</td>
+                <td>{p.price.toFixed(2)}</td>
+                <td>{p.discount}</td>
+                <td>
+                  <button onClick={() => { setEditingIndex(index); setShowForm(true) }}>Edit</button>
+                  <button onClick={() => deleteProduct(index)}>Delete</button>
+                </td>
+              </tr>
+            )
+          })}
         </tbody>
       </table>
       <div className="pagination">

--- a/my-app/src/ProductForm.css
+++ b/my-app/src/ProductForm.css
@@ -1,0 +1,13 @@
+.product-form {
+  margin-bottom: 1rem;
+}
+.product-form div {
+  margin-bottom: 0.5rem;
+}
+.product-form label {
+  display: flex;
+  flex-direction: column;
+}
+.form-actions button {
+  margin-right: 0.5rem;
+}

--- a/my-app/src/ProductForm.jsx
+++ b/my-app/src/ProductForm.jsx
@@ -1,0 +1,109 @@
+import { useState, useEffect } from 'react'
+import './ProductForm.css'
+
+const brands = ['Brand A', 'Brand B', 'Brand C']
+const categoriesOptions = ['Tools', 'Electronics', 'Accessories', 'Outdoor', 'Home']
+
+export default function ProductForm({ onSave, onCancel, initial }) {
+  const [image, setImage] = useState(initial?.image || '')
+  const [sku, setSku] = useState(initial?.sku || '')
+  const [name, setName] = useState(initial?.name || '')
+  const [brand, setBrand] = useState(initial?.brand || '')
+  const [categories, setCategories] = useState(initial?.categories || [])
+  const [price, setPrice] = useState(initial?.price || '')
+  const [discount, setDiscount] = useState(initial?.discount ?? 0)
+
+  useEffect(() => {
+    setImage(initial?.image || '')
+    setSku(initial?.sku || '')
+    setName(initial?.name || '')
+    setBrand(initial?.brand || '')
+    setCategories(initial?.categories || [])
+    setPrice(initial?.price || '')
+    setDiscount(initial?.discount ?? 0)
+  }, [initial])
+
+  const handleImageChange = e => {
+    const file = e.target.files[0]
+    if (file) {
+      const reader = new FileReader()
+      reader.onload = () => setImage(reader.result)
+      reader.readAsDataURL(file)
+    }
+  }
+
+  const handleCategoryChange = e => {
+    const options = Array.from(e.target.selectedOptions).map(o => o.value)
+    setCategories(options)
+  }
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    if (!/^[A-Z0-9]+$/.test(sku)) {
+      alert('SKU must be uppercase alphanumeric with no spaces or special characters.')
+      return
+    }
+    onSave({ image, sku, name, brand, categories, price: parseFloat(price || 0), discount: parseFloat(discount || 0) })
+  }
+
+  return (
+    <form className="product-form" onSubmit={handleSubmit}>
+      <div>
+        <label>
+          Product Image
+          <input type="file" accept="image/*" onChange={handleImageChange} />
+        </label>
+        {image && <img src={image} className="thumbnail" alt="preview" />}
+      </div>
+      <div>
+        <label>
+          SKU
+          <input value={sku} onChange={e => setSku(e.target.value.toUpperCase())} required />
+        </label>
+      </div>
+      <div>
+        <label>
+          Product Name
+          <input value={name} onChange={e => setName(e.target.value)} maxLength={50} required />
+        </label>
+      </div>
+      <div>
+        <label>
+          Brand
+          <select value={brand} onChange={e => setBrand(e.target.value)}>
+            <option value="">Select brand</option>
+            {brands.map(b => (
+              <option key={b} value={b}>{b}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div>
+        <label>
+          Categories
+          <select multiple value={categories} onChange={handleCategoryChange}>
+            {categoriesOptions.map(c => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div>
+        <label>
+          Price
+          <input type="number" step="0.01" value={price} onChange={e => setPrice(e.target.value)} required />
+        </label>
+      </div>
+      <div>
+        <label>
+          Discount %
+          <input type="number" step="0.01" value={discount} onChange={e => setDiscount(e.target.value)} min="0" max="100" />
+        </label>
+      </div>
+      <div className="form-actions">
+        <button type="submit">Save</button>
+        <button type="button" onClick={onCancel}>Cancel</button>
+      </div>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- create `ProductForm` for adding/editing products
- add CRUD logic to `ProductCatalog` with validation
- style new form with basic CSS
- ignore node modules in git

## Testing
- `npm run lint --workspace=my-app`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6848ac1be12c8324a96cdc90f57950cd