### PR TITLE
Add brand and category management

### DIFF
--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -3,10 +3,20 @@ import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
 import ProductCatalog from './ProductCatalog.jsx'
+import BrandCatalog from './BrandCatalog.jsx'
+import CategoryCatalog from './CategoryCatalog.jsx'
 
 function App() {
   const [count, setCount] = useState(0)
   const [page, setPage] = useState('home')
+  const [brands, setBrands] = useState(['Brand A', 'Brand B', 'Brand C'])
+  const [categories, setCategories] = useState([
+    'Tools',
+    'Electronics',
+    'Accessories',
+    'Outdoor',
+    'Home',
+  ])
 
   const homeContent = (
     <>
@@ -38,10 +48,23 @@ function App() {
       <aside className="sidebar">
         <button onClick={() => setPage('home')}>Home</button>
         <button onClick={() => setPage('products')}>Products</button>
+        <button onClick={() => setPage('brands')}>Brands</button>
+        <button onClick={() => setPage('categories')}>Categories</button>
       </aside>
       <main className="content">
         {page === 'home' && homeContent}
-        {page === 'products' && <ProductCatalog />}
+        {page === 'products' && (
+          <ProductCatalog brands={brands} categories={categories} />
+        )}
+        {page === 'brands' && (
+          <BrandCatalog brands={brands} setBrands={setBrands} />
+        )}
+        {page === 'categories' && (
+          <CategoryCatalog
+            categories={categories}
+            setCategories={setCategories}
+          />
+        )}
       </main>
     </div>
   )

--- a/my-app/src/BrandCatalog.jsx
+++ b/my-app/src/BrandCatalog.jsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+import './SimpleCatalog.css'
+
+export default function BrandCatalog({ brands, setBrands }) {
+  const [name, setName] = useState('')
+  const [editingIndex, setEditingIndex] = useState(null)
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    const value = name.trim()
+    if (!value) return
+    if (editingIndex !== null) {
+      setBrands(brands.map((b, i) => (i === editingIndex ? value : b)))
+      setEditingIndex(null)
+    } else {
+      setBrands([...brands, value])
+    }
+    setName('')
+  }
+
+  const edit = index => {
+    setName(brands[index])
+    setEditingIndex(index)
+  }
+
+  const remove = index => {
+    setBrands(brands.filter((_, i) => i !== index))
+  }
+
+  const cancel = () => {
+    setName('')
+    setEditingIndex(null)
+  }
+
+  return (
+    <div className="catalog">
+      <h2>Brands</h2>
+      <form onSubmit={handleSubmit} className="simple-form">
+        <input
+          placeholder="Brand name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          required
+        />
+        <button type="submit">{editingIndex !== null ? 'Update' : 'Add'}</button>
+        {editingIndex !== null && (
+          <button type="button" onClick={cancel}>Cancel</button>
+        )}
+      </form>
+      <ul className="simple-list">
+        {brands.map((b, i) => (
+          <li key={i}>
+            {b}
+            <button onClick={() => edit(i)}>Edit</button>
+            <button onClick={() => remove(i)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/my-app/src/CategoryCatalog.jsx
+++ b/my-app/src/CategoryCatalog.jsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+import './SimpleCatalog.css'
+
+export default function CategoryCatalog({ categories, setCategories }) {
+  const [name, setName] = useState('')
+  const [editingIndex, setEditingIndex] = useState(null)
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    const value = name.trim()
+    if (!value) return
+    if (editingIndex !== null) {
+      setCategories(categories.map((c, i) => (i === editingIndex ? value : c)))
+      setEditingIndex(null)
+    } else {
+      setCategories([...categories, value])
+    }
+    setName('')
+  }
+
+  const edit = index => {
+    setName(categories[index])
+    setEditingIndex(index)
+  }
+
+  const remove = index => {
+    setCategories(categories.filter((_, i) => i !== index))
+  }
+
+  const cancel = () => {
+    setName('')
+    setEditingIndex(null)
+  }
+
+  return (
+    <div className="catalog">
+      <h2>Categories</h2>
+      <form onSubmit={handleSubmit} className="simple-form">
+        <input
+          placeholder="Category name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          required
+        />
+        <button type="submit">{editingIndex !== null ? 'Update' : 'Add'}</button>
+        {editingIndex !== null && (
+          <button type="button" onClick={cancel}>Cancel</button>
+        )}
+      </form>
+      <ul className="simple-list">
+        {categories.map((c, i) => (
+          <li key={i}>
+            {c}
+            <button onClick={() => edit(i)}>Edit</button>
+            <button onClick={() => remove(i)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/my-app/src/ProductCatalog.jsx
+++ b/my-app/src/ProductCatalog.jsx
@@ -18,7 +18,7 @@ const initialProducts = [
   { sku: 'SKU012', name: 'Thingy L', categories: ['Accessories', 'Home'], price: 7.99, image: placeholder, brand: 'Brand C', discount: 0 }
 ]
 
-export default function ProductCatalog() {
+export default function ProductCatalog({ brands, categories }) {
   const [products, setProducts] = useState(initialProducts)
   const [editingIndex, setEditingIndex] = useState(null)
   const [showForm, setShowForm] = useState(false)
@@ -64,6 +64,8 @@ export default function ProductCatalog() {
           onSave={editingIndex !== null ? updateProduct : addProduct}
           onCancel={() => { setShowForm(false); setEditingIndex(null) }}
           initial={editingIndex !== null ? products[editingIndex] : null}
+          brands={brands}
+          categoriesOptions={categories}
         />
       ) : (
         <button onClick={() => setShowForm(true)}>Add Product</button>

--- a/my-app/src/ProductForm.jsx
+++ b/my-app/src/ProductForm.jsx
@@ -1,10 +1,7 @@
 import { useState, useEffect } from 'react'
 import './ProductForm.css'
 
-const brands = ['Brand A', 'Brand B', 'Brand C']
-const categoriesOptions = ['Tools', 'Electronics', 'Accessories', 'Outdoor', 'Home']
-
-export default function ProductForm({ onSave, onCancel, initial }) {
+export default function ProductForm({ onSave, onCancel, initial, brands = [], categoriesOptions = [] }) {
   const [image, setImage] = useState(initial?.image || '')
   const [sku, setSku] = useState(initial?.sku || '')
   const [name, setName] = useState(initial?.name || '')

--- a/my-app/src/SimpleCatalog.css
+++ b/my-app/src/SimpleCatalog.css
@@ -1,0 +1,17 @@
+.simple-form {
+  margin-bottom: 1rem;
+}
+.simple-form input {
+  margin-right: 0.5rem;
+  padding: 0.25rem;
+}
+.simple-list {
+  list-style: none;
+  padding-left: 0;
+}
+.simple-list li {
+  margin-bottom: 0.5rem;
+}
+.simple-list button {
+  margin-left: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- create CRUD components for brands and categories
- add a simple catalog stylesheet
- make product form configurable with brand & category lists
- update product catalog to accept option lists
- extend app navigation with brands and categories pages

## Testing
- `npm run build --workspace=my-app`
- `npm run lint --workspace=my-app`


------
https://chatgpt.com/codex/tasks/task_e_6848b0a04ab88324829f502082e9ff1b