### PR TITLE
Separate edit views and placeholder image

### DIFF
--- a/my-app/src/BrandCatalog.jsx
+++ b/my-app/src/BrandCatalog.jsx
@@ -10,6 +10,7 @@ import ListItemText from '@mui/material/ListItemText'
 export default function BrandCatalog({ brands, setBrands }) {
   const [name, setName] = useState('')
   const [editingIndex, setEditingIndex] = useState(null)
+  const [showForm, setShowForm] = useState(false)
 
   const handleSubmit = e => {
     e.preventDefault()
@@ -22,11 +23,13 @@ export default function BrandCatalog({ brands, setBrands }) {
       setBrands([...brands, value])
     }
     setName('')
+    setShowForm(false)
   }
 
   const edit = index => {
     setName(brands[index])
     setEditingIndex(index)
+    setShowForm(true)
   }
 
   const remove = index => {
@@ -36,39 +39,48 @@ export default function BrandCatalog({ brands, setBrands }) {
   const cancel = () => {
     setName('')
     setEditingIndex(null)
+    setShowForm(false)
+  }
+
+  if (showForm) {
+    return (
+      <Box>
+        <Typography variant="h5" sx={{ mb: 2 }}>
+          {editingIndex !== null ? 'Edit Brand' : 'Add Brand'}
+        </Typography>
+        <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', gap: 1 }}>
+          <TextField
+            label="Brand name"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            required
+          />
+          <Button type="submit" variant="contained">
+            {editingIndex !== null ? 'Update' : 'Add'}
+          </Button>
+          <Button type="button" onClick={cancel}>Cancel</Button>
+        </Box>
+      </Box>
+    )
   }
 
   return (
     <Box>
       <Typography variant="h5" sx={{ mb: 2 }}>Brands</Typography>
-      <Box
-        component="form"
-        onSubmit={handleSubmit}
-        sx={{ display: 'flex', gap: 1, mb: 2 }}
-      >
-        <TextField
-          label="Brand name"
-          value={name}
-          onChange={e => setName(e.target.value)}
-          required
-        />
-        <Button type="submit" variant="contained">
-          {editingIndex !== null ? 'Update' : 'Add'}
-        </Button>
-        {editingIndex !== null && (
-          <Button type="button" onClick={cancel}>
-            Cancel
-          </Button>
-        )}
-      </Box>
+      <Button variant="contained" sx={{ mb: 2 }} onClick={() => { setShowForm(true); setName(''); setEditingIndex(null) }}>
+        Add Brand
+      </Button>
       <List>
         {brands.map((b, i) => (
-          <ListItem key={i} secondaryAction={
-            <Box>
-              <Button size="small" onClick={() => edit(i)}>Edit</Button>
-              <Button size="small" onClick={() => remove(i)}>Delete</Button>
-            </Box>
-          }>
+          <ListItem
+            key={i}
+            secondaryAction={
+              <Box>
+                <Button size="small" onClick={() => edit(i)}>Edit</Button>
+                <Button size="small" onClick={() => remove(i)}>Delete</Button>
+              </Box>
+            }
+          >
             <ListItemText primary={b} />
           </ListItem>
         ))}

--- a/my-app/src/CategoryCatalog.jsx
+++ b/my-app/src/CategoryCatalog.jsx
@@ -10,6 +10,7 @@ import ListItemText from '@mui/material/ListItemText'
 export default function CategoryCatalog({ categories, setCategories }) {
   const [name, setName] = useState('')
   const [editingIndex, setEditingIndex] = useState(null)
+  const [showForm, setShowForm] = useState(false)
 
   const handleSubmit = e => {
     e.preventDefault()
@@ -22,11 +23,13 @@ export default function CategoryCatalog({ categories, setCategories }) {
       setCategories([...categories, value])
     }
     setName('')
+    setShowForm(false)
   }
 
   const edit = index => {
     setName(categories[index])
     setEditingIndex(index)
+    setShowForm(true)
   }
 
   const remove = index => {
@@ -36,37 +39,48 @@ export default function CategoryCatalog({ categories, setCategories }) {
   const cancel = () => {
     setName('')
     setEditingIndex(null)
+    setShowForm(false)
+  }
+
+  if (showForm) {
+    return (
+      <Box>
+        <Typography variant="h5" sx={{ mb: 2 }}>
+          {editingIndex !== null ? 'Edit Category' : 'Add Category'}
+        </Typography>
+        <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', gap: 1 }}>
+          <TextField
+            label="Category name"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            required
+          />
+          <Button type="submit" variant="contained">
+            {editingIndex !== null ? 'Update' : 'Add'}
+          </Button>
+          <Button type="button" onClick={cancel}>Cancel</Button>
+        </Box>
+      </Box>
+    )
   }
 
   return (
     <Box>
       <Typography variant="h5" sx={{ mb: 2 }}>Categories</Typography>
-      <Box
-        component="form"
-        onSubmit={handleSubmit}
-        sx={{ display: 'flex', gap: 1, mb: 2 }}
-      >
-        <TextField
-          label="Category name"
-          value={name}
-          onChange={e => setName(e.target.value)}
-          required
-        />
-        <Button type="submit" variant="contained">
-          {editingIndex !== null ? 'Update' : 'Add'}
-        </Button>
-        {editingIndex !== null && (
-          <Button type="button" onClick={cancel}>Cancel</Button>
-        )}
-      </Box>
+      <Button variant="contained" sx={{ mb: 2 }} onClick={() => { setShowForm(true); setName(''); setEditingIndex(null) }}>
+        Add Category
+      </Button>
       <List>
         {categories.map((c, i) => (
-          <ListItem key={i} secondaryAction={
-            <Box>
-              <Button size="small" onClick={() => edit(i)}>Edit</Button>
-              <Button size="small" onClick={() => remove(i)}>Delete</Button>
-            </Box>
-          }>
+          <ListItem
+            key={i}
+            secondaryAction={
+              <Box>
+                <Button size="small" onClick={() => edit(i)}>Edit</Button>
+                <Button size="small" onClick={() => remove(i)}>Delete</Button>
+              </Box>
+            }
+          >
             <ListItemText primary={c} />
           </ListItem>
         ))}

--- a/my-app/src/ProductCatalog.jsx
+++ b/my-app/src/ProductCatalog.jsx
@@ -64,20 +64,32 @@ export default function ProductCatalog({ brands, categories }) {
   const prevPage = () => setPage(p => Math.max(1, p - 1))
   const nextPage = () => setPage(p => Math.min(totalPages, p + 1))
 
-  return (
-    <Box>
-      <Typography variant="h5" sx={{ mb: 2 }}>Product Catalog</Typography>
-      {showForm ? (
+  if (showForm) {
+    return (
+      <Box>
+        <Typography variant="h5" sx={{ mb: 2 }}>
+          {editingIndex !== null ? 'Edit Product' : 'Add Product'}
+        </Typography>
         <ProductForm
           onSave={editingIndex !== null ? updateProduct : addProduct}
-          onCancel={() => { setShowForm(false); setEditingIndex(null) }}
+          onCancel={() => {
+            setShowForm(false)
+            setEditingIndex(null)
+          }}
           initial={editingIndex !== null ? products[editingIndex] : null}
           brands={brands}
           categoriesOptions={categories}
         />
-      ) : (
-        <Button variant="contained" onClick={() => setShowForm(true)}>Add Product</Button>
-      )}
+      </Box>
+    )
+  }
+
+  return (
+    <Box>
+      <Typography variant="h5" sx={{ mb: 2 }}>Product Catalog</Typography>
+      <Button variant="contained" onClick={() => setShowForm(true)}>
+        Add Product
+      </Button>
       <TextField
         placeholder="Search..."
         value={search}

--- a/my-app/src/ProductForm.jsx
+++ b/my-app/src/ProductForm.jsx
@@ -1,4 +1,6 @@
 import { useState, useEffect } from 'react'
+
+const placeholder = 'https://via.placeholder.com/50'
 import Box from '@mui/material/Box'
 import TextField from '@mui/material/TextField'
 import Button from '@mui/material/Button'
@@ -45,7 +47,15 @@ export default function ProductForm({ onSave, onCancel, initial, brands = [], ca
       alert('SKU must be uppercase alphanumeric with no spaces or special characters.')
       return
     }
-    onSave({ image, sku, name, brand, categories, price: parseFloat(price || 0), discount: parseFloat(discount || 0) })
+    onSave({
+      image: image || placeholder,
+      sku,
+      name,
+      brand,
+      categories,
+      price: parseFloat(price || 0),
+      discount: parseFloat(discount || 0),
+    })
   }
 
   return (
@@ -55,9 +65,12 @@ export default function ProductForm({ onSave, onCancel, initial, brands = [], ca
           Upload Image
           <input hidden type="file" accept="image/*" onChange={handleImageChange} />
         </Button>
-        {image && (
-          <Box component="img" src={image} alt="preview" sx={{ width: 50, display: 'block', mt: 1 }} />
-        )}
+        <Box
+          component="img"
+          src={image || placeholder}
+          alt="preview"
+          sx={{ width: 50, display: 'block', mt: 1 }}
+        />
       </div>
       <TextField label="SKU" value={sku} onChange={e => setSku(e.target.value.toUpperCase())} required />
       <TextField label="Product Name" value={name} onChange={e => setName(e.target.value)} inputProps={{ maxLength: 50 }} required />


### PR DESCRIPTION
## Summary
- show add/edit forms in their own views for products, brands and categories
- display generic placeholder when a product image is not provided

## Testing
- `npm run lint --workspace=my-app`
- `npm run build --workspace=my-app`


------
https://chatgpt.com/codex/tasks/task_e_6848c6df25b483249ba6e61ac443f8ca