### PR TITLE
Update layout of catalog sections

### DIFF
--- a/my-app/src/BrandCatalog.jsx
+++ b/my-app/src/BrandCatalog.jsx
@@ -45,9 +45,6 @@ export default function BrandCatalog({ brands, setBrands }) {
   if (showForm) {
     return (
       <Box>
-        <Typography variant="h5" sx={{ mb: 2 }}>
-          {editingIndex !== null ? 'Edit Brand' : 'Add Brand'}
-        </Typography>
         <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', gap: 1 }}>
           <TextField
             label="Brand name"
@@ -66,10 +63,11 @@ export default function BrandCatalog({ brands, setBrands }) {
 
   return (
     <Box>
-      <Typography variant="h5" sx={{ mb: 2 }}>Brands</Typography>
-      <Button variant="contained" sx={{ mb: 2 }} onClick={() => { setShowForm(true); setName(''); setEditingIndex(null) }}>
-        Add Brand
-      </Button>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
+        <Button variant="contained" onClick={() => { setShowForm(true); setName(''); setEditingIndex(null) }}>
+          Add Brand
+        </Button>
+      </Box>
       <List>
         {brands.map((b, i) => (
           <ListItem

--- a/my-app/src/CategoryCatalog.jsx
+++ b/my-app/src/CategoryCatalog.jsx
@@ -45,9 +45,6 @@ export default function CategoryCatalog({ categories, setCategories }) {
   if (showForm) {
     return (
       <Box>
-        <Typography variant="h5" sx={{ mb: 2 }}>
-          {editingIndex !== null ? 'Edit Category' : 'Add Category'}
-        </Typography>
         <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', gap: 1 }}>
           <TextField
             label="Category name"
@@ -66,10 +63,11 @@ export default function CategoryCatalog({ categories, setCategories }) {
 
   return (
     <Box>
-      <Typography variant="h5" sx={{ mb: 2 }}>Categories</Typography>
-      <Button variant="contained" sx={{ mb: 2 }} onClick={() => { setShowForm(true); setName(''); setEditingIndex(null) }}>
-        Add Category
-      </Button>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
+        <Button variant="contained" onClick={() => { setShowForm(true); setName(''); setEditingIndex(null) }}>
+          Add Category
+        </Button>
+      </Box>
       <List>
         {categories.map((c, i) => (
           <ListItem

--- a/my-app/src/ProductCatalog.jsx
+++ b/my-app/src/ProductCatalog.jsx
@@ -67,9 +67,6 @@ export default function ProductCatalog({ brands, categories }) {
   if (showForm) {
     return (
       <Box>
-        <Typography variant="h5" sx={{ mb: 2 }}>
-          {editingIndex !== null ? 'Edit Product' : 'Add Product'}
-        </Typography>
         <ProductForm
           onSave={editingIndex !== null ? updateProduct : addProduct}
           onCancel={() => {
@@ -86,15 +83,16 @@ export default function ProductCatalog({ brands, categories }) {
 
   return (
     <Box>
-      <Typography variant="h5" sx={{ mb: 2 }}>Product Catalog</Typography>
-      <Button variant="contained" onClick={() => setShowForm(true)}>
-        Add Product
-      </Button>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
+        <Button variant="contained" onClick={() => setShowForm(true)}>
+          Add Product
+        </Button>
+      </Box>
       <TextField
         placeholder="Search..."
         value={search}
         onChange={e => { setSearch(e.target.value); setPage(1) }}
-        sx={{ my: 2 }}
+        sx={{ mb: 2 }}
       />
       <Table>
         <TableHead>


### PR DESCRIPTION
## Summary
- remove `Typography` h5 headings from the catalog sections
- right align the `Add` buttons and keep search field below

## Testing
- `npm test`
- `npm run lint --workspace=my-app` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848cae2e0ec832496c3c5da4355087a