### PR TITLE
Add NestJS backend services

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,18 @@
+# Backend Services
+
+This folder contains a small NestJS application exposing CRUD APIs for brands, categories and products.
+The project uses TypeORM with a MariaDB database. Database connection options can be configured via environment variables:
+
+```
+DB_HOST, DB_PORT, DB_USER, DB_PASS, DB_NAME
+```
+
+To run locally:
+
+```bash
+npm install
+
+npm run start:dev
+```
+
+The app listens on port **3001**.

--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "saas-backend",
+  "version": "1.0.0",
+  "description": "NestJS backend for product catalog",
+  "private": true,
+  "scripts": {
+    "start": "nest start",
+    "start:dev": "nest start --watch"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/typeorm": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1",
+    "typeorm": "^0.3.17",
+    "mysql": "^2.18.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ProductModule } from './product/product.module';
+import { BrandModule } from './brand/brand.module';
+import { CategoryModule } from './category/category.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'mariadb',
+      host: process.env.DB_HOST || 'localhost',
+      port: +(process.env.DB_PORT || 3306),
+      username: process.env.DB_USER || 'root',
+      password: process.env.DB_PASS || 'password',
+      database: process.env.DB_NAME || 'products',
+      autoLoadEntities: true,
+      synchronize: true,
+    }),
+    ProductModule,
+    BrandModule,
+    CategoryModule,
+  ],
+})
+export class AppModule {}

--- a/backend/src/brand/brand.controller.ts
+++ b/backend/src/brand/brand.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Param, Put, Delete } from '@nestjs/common';
+import { BrandService } from './brand.service';
+import { CreateBrandDto } from './dto/create-brand.dto';
+import { UpdateBrandDto } from './dto/update-brand.dto';
+
+@Controller('brands')
+export class BrandController {
+  constructor(private service: BrandService) {}
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(+id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateBrandDto) {
+    return this.service.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateBrandDto) {
+    return this.service.update(+id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.delete(+id);
+  }
+}

--- a/backend/src/brand/brand.entity.ts
+++ b/backend/src/brand/brand.entity.ts
@@ -1,0 +1,14 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { Product } from '../product/product.entity';
+
+@Entity('brands')
+export class Brand {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  name: string;
+
+  @OneToMany(() => Product, product => product.brand)
+  products: Product[];
+}

--- a/backend/src/brand/brand.module.ts
+++ b/backend/src/brand/brand.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Brand } from './brand.entity';
+import { BrandService } from './brand.service';
+import { BrandController } from './brand.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Brand])],
+  providers: [BrandService],
+  controllers: [BrandController],
+})
+export class BrandModule {}

--- a/backend/src/brand/brand.service.ts
+++ b/backend/src/brand/brand.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Brand } from './brand.entity';
+import { CreateBrandDto } from './dto/create-brand.dto';
+import { UpdateBrandDto } from './dto/update-brand.dto';
+
+@Injectable()
+export class BrandService {
+  constructor(
+    @InjectRepository(Brand) private repo: Repository<Brand>,
+  ) {}
+
+  findAll() {
+    return this.repo.find();
+  }
+
+  findOne(id: number) {
+    return this.repo.findOne({ where: { id } });
+  }
+
+  create(dto: CreateBrandDto) {
+    const brand = this.repo.create(dto);
+    return this.repo.save(brand);
+  }
+
+  async update(id: number, dto: UpdateBrandDto) {
+    await this.repo.update(id, dto);
+    return this.findOne(id);
+  }
+
+  delete(id: number) {
+    return this.repo.delete(id);
+  }
+}

--- a/backend/src/brand/dto/create-brand.dto.ts
+++ b/backend/src/brand/dto/create-brand.dto.ts
@@ -1,0 +1,3 @@
+export class CreateBrandDto {
+  name: string;
+}

--- a/backend/src/brand/dto/update-brand.dto.ts
+++ b/backend/src/brand/dto/update-brand.dto.ts
@@ -1,0 +1,3 @@
+export class UpdateBrandDto {
+  name?: string;
+}

--- a/backend/src/category/category.controller.ts
+++ b/backend/src/category/category.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Param, Put, Delete } from '@nestjs/common';
+import { CategoryService } from './category.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+
+@Controller('categories')
+export class CategoryController {
+  constructor(private service: CategoryService) {}
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(+id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateCategoryDto) {
+    return this.service.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateCategoryDto) {
+    return this.service.update(+id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.delete(+id);
+  }
+}

--- a/backend/src/category/category.entity.ts
+++ b/backend/src/category/category.entity.ts
@@ -1,0 +1,14 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToMany } from 'typeorm';
+import { Product } from '../product/product.entity';
+
+@Entity('categories')
+export class Category {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  name: string;
+
+  @ManyToMany(() => Product, product => product.categories)
+  products: Product[];
+}

--- a/backend/src/category/category.module.ts
+++ b/backend/src/category/category.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Category } from './category.entity';
+import { CategoryService } from './category.service';
+import { CategoryController } from './category.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Category])],
+  providers: [CategoryService],
+  controllers: [CategoryController],
+})
+export class CategoryModule {}

--- a/backend/src/category/category.service.ts
+++ b/backend/src/category/category.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Category } from './category.entity';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+
+@Injectable()
+export class CategoryService {
+  constructor(
+    @InjectRepository(Category) private repo: Repository<Category>,
+  ) {}
+
+  findAll() {
+    return this.repo.find();
+  }
+
+  findOne(id: number) {
+    return this.repo.findOne({ where: { id } });
+  }
+
+  create(dto: CreateCategoryDto) {
+    const category = this.repo.create(dto);
+    return this.repo.save(category);
+  }
+
+  async update(id: number, dto: UpdateCategoryDto) {
+    await this.repo.update(id, dto);
+    return this.findOne(id);
+  }
+
+  delete(id: number) {
+    return this.repo.delete(id);
+  }
+}

--- a/backend/src/category/dto/create-category.dto.ts
+++ b/backend/src/category/dto/create-category.dto.ts
@@ -1,0 +1,3 @@
+export class CreateCategoryDto {
+  name: string;
+}

--- a/backend/src/category/dto/update-category.dto.ts
+++ b/backend/src/category/dto/update-category.dto.ts
@@ -1,0 +1,3 @@
+export class UpdateCategoryDto {
+  name?: string;
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3001);
+}
+bootstrap();

--- a/backend/src/product/dto/create-product.dto.ts
+++ b/backend/src/product/dto/create-product.dto.ts
@@ -1,0 +1,9 @@
+export class CreateProductDto {
+  sku: string;
+  name: string;
+  brandId: number;
+  categoryIds: number[];
+  price: number;
+  imageUrl?: string;
+  discount?: number;
+}

--- a/backend/src/product/dto/update-product.dto.ts
+++ b/backend/src/product/dto/update-product.dto.ts
@@ -1,0 +1,9 @@
+export class UpdateProductDto {
+  sku?: string;
+  name?: string;
+  brandId?: number;
+  categoryIds?: number[];
+  price?: number;
+  imageUrl?: string;
+  discount?: number;
+}

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Param, Put, Delete } from '@nestjs/common';
+import { ProductService } from './product.service';
+import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
+
+@Controller('products')
+export class ProductController {
+  constructor(private service: ProductService) {}
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(+id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateProductDto) {
+    return this.service.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateProductDto) {
+    return this.service.update(+id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.delete(+id);
+  }
+}

--- a/backend/src/product/product.entity.ts
+++ b/backend/src/product/product.entity.ts
@@ -1,0 +1,31 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, ManyToMany, JoinTable } from 'typeorm';
+import { Brand } from '../brand/brand.entity';
+import { Category } from '../category/category.entity';
+
+@Entity('products')
+export class Product {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  sku: string;
+
+  @Column()
+  name: string;
+
+  @ManyToOne(() => Brand, brand => brand.products, { eager: true })
+  brand: Brand;
+
+  @ManyToMany(() => Category, category => category.products, { eager: true })
+  @JoinTable({ name: 'product_categories' })
+  categories: Category[];
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  price: number;
+
+  @Column({ name: 'image_url', nullable: true })
+  imageUrl: string;
+
+  @Column('decimal', { precision: 5, scale: 2, default: 0 })
+  discount: number;
+}

--- a/backend/src/product/product.module.ts
+++ b/backend/src/product/product.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Product } from './product.entity';
+import { Brand } from '../brand/brand.entity';
+import { Category } from '../category/category.entity';
+import { ProductService } from './product.service';
+import { ProductController } from './product.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Product, Brand, Category])],
+  providers: [ProductService],
+  controllers: [ProductController],
+})
+export class ProductModule {}

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Product } from './product.entity';
+import { Brand } from '../brand/brand.entity';
+import { Category } from '../category/category.entity';
+import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
+
+@Injectable()
+export class ProductService {
+  constructor(
+    @InjectRepository(Product) private repo: Repository<Product>,
+    @InjectRepository(Brand) private brandRepo: Repository<Brand>,
+    @InjectRepository(Category) private catRepo: Repository<Category>,
+  ) {}
+
+  findAll() {
+    return this.repo.find();
+  }
+
+  findOne(id: number) {
+    return this.repo.findOne({ where: { id } });
+  }
+
+  async create(dto: CreateProductDto) {
+    const brand = await this.brandRepo.findOne({ where: { id: dto.brandId } });
+    const categories = await this.catRepo.findByIds(dto.categoryIds || []);
+    const product = this.repo.create({
+      sku: dto.sku,
+      name: dto.name,
+      brand,
+      categories,
+      price: dto.price,
+      imageUrl: dto.imageUrl,
+      discount: dto.discount || 0,
+    });
+    return this.repo.save(product);
+  }
+
+  async update(id: number, dto: UpdateProductDto) {
+    const product = await this.findOne(id);
+    if (dto.brandId) {
+      product.brand = await this.brandRepo.findOne({ where: { id: dto.brandId } });
+    }
+    if (dto.categoryIds) {
+      product.categories = await this.catRepo.findByIds(dto.categoryIds);
+    }
+    Object.assign(product, {
+      sku: dto.sku ?? product.sku,
+      name: dto.name ?? product.name,
+      price: dto.price ?? product.price,
+      imageUrl: dto.imageUrl ?? product.imageUrl,
+      discount: dto.discount ?? product.discount,
+    });
+    return this.repo.save(product);
+  }
+
+  delete(id: number) {
+    return this.repo.delete(id);
+  }
+}

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "",
   "main": "index.js",
   "workspaces": [
-    "my-app"
+    "my-app",
+    "backend"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Summary
- add a `backend` workspace with a NestJS app
- implement TypeORM entities and CRUD modules for Brand, Category and Product
- hook new workspace in root `package.json`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6848cbeb8c948324b02b9ff7b76a4df7