### PR TITLE
Configure backend to connect to Cloud SQL

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,7 +1,15 @@
 # Backend Services
 
 This folder contains a small NestJS application exposing CRUD APIs for brands, categories and products.
-The project uses TypeORM with a MariaDB database. Database connection options can be configured via environment variables:
+The project uses TypeORM with a MySQL database hosted on Google Cloud SQL. Database connection options can be configured via environment variables. By default the application connects to the Cloud SQL instance using the following settings:
+
+```
+host: 34.58.204.105
+user: root
+password: FgyyB}=^.}Sct.Q]
+database: test-db
+```
+
 
 ```
 DB_HOST, DB_PORT, DB_USER, DB_PASS, DB_NAME

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,12 +7,12 @@ import { CategoryModule } from './category/category.module';
 @Module({
   imports: [
     TypeOrmModule.forRoot({
-      type: 'mariadb',
-      host: process.env.DB_HOST || 'localhost',
+      type: 'mysql',
+      host: process.env.DB_HOST || '34.58.204.105',
       port: +(process.env.DB_PORT || 3306),
       username: process.env.DB_USER || 'root',
-      password: process.env.DB_PASS || 'password',
-      database: process.env.DB_NAME || 'products',
+      password: process.env.DB_PASS || 'FgyyB}=^.}Sct.Q]',
+      database: process.env.DB_NAME || 'test-db',
       autoLoadEntities: true,
       synchronize: true,
     }),


### PR DESCRIPTION
## Summary
- point the NestJS backend to a Google Cloud SQL MySQL instance
- document the default Cloud SQL connection details

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_6849c83cd8608324a4a62b16de0122ac