### PR TITLE
Add validation for category name

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,9 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17",
-    "mysql": "^2.18.1"
+    "mysql": "^2.18.1",
+    "class-validator": "^0.14.0",
+    "class-transformer": "^0.5.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/backend/src/category/category.entity.ts
+++ b/backend/src/category/category.entity.ts
@@ -6,7 +6,7 @@ export class Category {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ unique: true })
+  @Column({ unique: true, length: 50 })
   name: string;
 
   @ManyToMany(() => Product, product => product.categories)

--- a/backend/src/category/dto/create-category.dto.ts
+++ b/backend/src/category/dto/create-category.dto.ts
@@ -1,3 +1,7 @@
+import { IsString, MaxLength } from 'class-validator';
+
 export class CreateCategoryDto {
+  @IsString()
+  @MaxLength(50)
   name: string;
 }

--- a/backend/src/category/dto/update-category.dto.ts
+++ b/backend/src/category/dto/update-category.dto.ts
@@ -1,3 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
 export class UpdateCategoryDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
   name?: string;
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe());
   await app.listen(3001);
 }
 bootstrap();


### PR DESCRIPTION
## Summary
- restrict Category entity name to 50 characters
- use `class-validator` in DTOs
- enable validation globally in NestJS

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685da39122408324bf9614c4f4defaa3