### PR TITLE
Update category name validation

### DIFF
--- a/backend/src/category/category.entity.ts
+++ b/backend/src/category/category.entity.ts
@@ -6,7 +6,7 @@ export class Category {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ unique: true, length: 50 })
+  @Column({ unique: true, length: 30 })
   name: string;
 
   @ManyToMany(() => Product, product => product.categories)

--- a/backend/src/category/dto/create-category.dto.ts
+++ b/backend/src/category/dto/create-category.dto.ts
@@ -2,6 +2,6 @@ import { IsString, MaxLength } from 'class-validator';
 
 export class CreateCategoryDto {
   @IsString()
-  @MaxLength(50)
+  @MaxLength(30)
   name: string;
 }

--- a/backend/src/category/dto/update-category.dto.ts
+++ b/backend/src/category/dto/update-category.dto.ts
@@ -3,6 +3,6 @@ import { IsOptional, IsString, MaxLength } from 'class-validator';
 export class UpdateCategoryDto {
   @IsOptional()
   @IsString()
-  @MaxLength(50)
+  @MaxLength(30)
   name?: string;
 }


### PR DESCRIPTION
## Summary
- enforce 30 character limit for `Category` entity field
- update DTO validation rules to use 30 characters

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685da4a49d448324bd4928d843a131fe